### PR TITLE
Fix build on php-fpm image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LUAJIT_INC=/usr/include/luajit-2.0
 
 # resolves #166
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
-RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing gnu-libiconv
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community gnu-libiconv
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
   && CONFIG="\

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV LUAJIT_INC=/usr/include/luajit-2.0
 
 # resolves #166
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+RUN apk add --upgrade apk-tools
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community gnu-libiconv
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \


### PR DESCRIPTION
Users are getting the following when building the image. Using this site I can see using `community` is needed to get this package: https://pkgs.alpinelinux.org/contents?file=&path=&name=gnu-libiconv&branch=edge&repo=community&arch=x86

*Error*:
`The command '/bin/sh -c apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing gnu-libiconv' returned a non-zero code: 1`

*Reported*:
https://circlefin.slack.com/archives/CCQRL94M6/p1551990525018200
And also I'm getting this error locally